### PR TITLE
feat: hide stacktrace in case of failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-alpine-slim
 RUN apk update && \
-    apk add --no-cache jq
+    apk add --no-cache jq \
+    apk add --no-cache unzip
 COPY /build/distributions/google-play-cli /usr/local/
+RUN chmod +x /usr/local/google-play-cli

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/core/BaseCommand.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/core/BaseCommand.kt
@@ -5,33 +5,50 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.validate
 import com.github.vacxe.googleplaycli.PlayStoreApi
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
 import java.security.InvalidParameterException
 
-abstract class BaseCommand(name: String, actionDescription: String = "") : CliktCommand(name = name, help = actionDescription) {
+abstract class BaseCommand(name: String, actionDescription: String = "") :
+    CliktCommand(name = name, help = actionDescription) {
 
-    private val serviceAccountJsonFile: String by option("--config-file", "-cf", help = "service account json file path")
-        .default(System.getenv("PLAYSTORE_SERVICE_ACCOUNT_JSON_FILE")
-            ?: "")
+    private val serviceAccountJsonFile: String by option(
+        "--config-file",
+        "-cf",
+        help = "service account json file path"
+    )
+        .default(
+            System.getenv("PLAYSTORE_SERVICE_ACCOUNT_JSON_FILE")
+                ?: ""
+        )
 
-    private val serviceAccountJsonContent: String by option("--config-content", "-cc", help = "service account json content")
-            .default(System.getenv("PLAYSTORE_SERVICE_ACCOUNT_JSON_CONTENT")
-                    ?: "")
+    private val serviceAccountJsonContent: String by option(
+        "--config-content",
+        "-cc",
+        help = "service account json content"
+    )
+        .default(
+            System.getenv("PLAYSTORE_SERVICE_ACCOUNT_JSON_CONTENT")
+                ?: ""
+        )
 
     val packageName: String by option("--package-name", "-p", help = "package name (example: com.my.app)")
-            .default(System.getenv("APP_PACKAGE_NAME") ?: "")
-            .validate { require(it.isNotEmpty()) { "Please provide a valid $help" } }
+        .default(System.getenv("APP_PACKAGE_NAME") ?: "")
+        .validate { require(it.isNotEmpty()) { "Please provide a valid $help" } }
+
+    private val debug: String by option("--debug", help = "enable debug logs")
+        .default("false")
 
     private val serviceAccountInputStream: InputStream
         get() {
-            if(serviceAccountJsonFile.isNotEmpty() && serviceAccountJsonContent.isNotEmpty()) {
+            if (serviceAccountJsonFile.isNotEmpty() && serviceAccountJsonContent.isNotEmpty()) {
                 throw InvalidParameterException("Service account file or content can't be specified together")
             }
 
-            if(serviceAccountJsonFile.isEmpty() && serviceAccountJsonContent.isEmpty()) {
+            if (serviceAccountJsonFile.isEmpty() && serviceAccountJsonContent.isEmpty()) {
                 throw InvalidParameterException("Service account File or Content need to be specified")
             }
 
@@ -39,18 +56,27 @@ abstract class BaseCommand(name: String, actionDescription: String = "") : Clikt
                 serviceAccountJsonContent.isNotEmpty() -> ByteArrayInputStream(serviceAccountJsonContent.toByteArray())
                 serviceAccountJsonFile.isNotEmpty() -> {
                     val serviceAccountFile = File(serviceAccountJsonFile)
-                    if(!serviceAccountFile.exists())
+                    if (!serviceAccountFile.exists())
                         throw InvalidParameterException("Service account file $serviceAccountJsonFile not exist")
                     FileInputStream(serviceAccountFile)
                 }
+
                 else -> throw InvalidParameterException("Service account input stream can't be defined")
             }
         }
 
     final override fun run() {
         val manager = PlayStoreApi(serviceAccountInputStream, packageName)
-        run(manager)?.let {
-            println(it)
+        try {
+            run(manager)?.let {
+                println(it)
+            }
+        } catch (e: GoogleJsonResponseException) {
+            if (debug.toBoolean()) {
+                e.printStackTrace()
+            } else {
+                println(e.content)
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/core/BaseCommand.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/core/BaseCommand.kt
@@ -11,6 +11,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
 import java.security.InvalidParameterException
+import kotlin.system.exitProcess
 
 abstract class BaseCommand(name: String, actionDescription: String = "") :
     CliktCommand(name = name, help = actionDescription) {
@@ -77,6 +78,7 @@ abstract class BaseCommand(name: String, actionDescription: String = "") :
             } else {
                 println(e.content)
             }
+            exitProcess(1)
         }
     }
 


### PR DESCRIPTION
Error default behavior example:
```
{
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "Package not found: com.github.vacxe.airqualitya.",
    "reason" : "notFound"
  } ],
  "message" : "Package not found: com.github.vacxe.airqualitya.",
  "status" : "NOT_FOUND"
}

Process finished with exit code 1
```

`--debug=true` : 
```
com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
POST https://www.googleapis.com/androidpublisher/v3/applications/com.github.vacxe.airqualitya/edits
{
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "Package not found: com.github.vacxe.airqualitya.",
    "reason" : "notFound"
  } ],
  "message" : "Package not found: com.github.vacxe.airqualitya.",
  "status" : "NOT_FOUND"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:150)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:321)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:419)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:469)
	at com.github.vacxe.googleplaycli.actions.Apks$DefaultImpls.apksList(Apks.kt:15)
	at com.github.vacxe.googleplaycli.PlayStoreApi.apksList(PlayStoreApi.kt:14)
	at com.github.vacxe.googleplaycli.Commands$Apks$List.run(Commands.kt:14)
	at com.github.vacxe.googleplaycli.Commands$Apks$List.run(Commands.kt:13)
	at com.github.vacxe.googleplaycli.core.BaseCommand.run(BaseCommand.kt:71)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:154)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:162)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:162)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:14)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:252)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:249)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:267)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:290)
	at com.github.vacxe.googleplaycli.PlayStoreCliKt.main(PlayStoreCli.kt:89)

Process finished with exit code 1

```